### PR TITLE
riscv: validate csr address in read/write_csr_progbuf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix: Update STM32G0_Series.yaml to include latest variants (STM32G050, STM32G051, STM32G061, STM32G0B0, STM32G0B1, STM32G0C1) (#1266)
 - Fix: Correct flash algorithm values in LPC55S69.yaml. (#1220)
 - Fix: Timeout during flashing when using connect under reset - regression from #1259. (#1286)
+- Fix: Validate RiscV CSR addresses to avoid unnecessary panics. (#1291)
 
 ## [0.13.0]
 


### PR DESCRIPTION
This will allow the read/write_csr call to return a proper error, rather than panicking.